### PR TITLE
fix dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 6.0.100-preview.1.21103.13
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,9 +11,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21105.12">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21125.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>938b3e8b4edcd96ca0f0cbbae63c87b3f51f7afe</Sha>
+      <Sha>15246f4af00a1cb2e580783d32ec2937b1878a64</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Libs -->
-    <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
+    <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.1</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>3.9.0-5.21120.8</MicrosoftCodeAnalysisVersion>
     <NugetProjectModelVersion>5.8.0</NugetProjectModelVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,6 @@
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.1</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>3.9.0-5.21120.8</MicrosoftCodeAnalysisVersion>
-    <NugetProjectModelVersion>5.8.0</NugetProjectModelVersion>
+    <NugetProjectModelVersion>5.8.1</NugetProjectModelVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "5.0.102"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21105.12"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21125.5"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.102"
+      "dotnet": "6.0.100-preview.1.21103.13"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21125.5"

--- a/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.DotNet.HotReload.Utils.Generator</PackageId>
@@ -27,6 +27,9 @@
         "ProcessFrameworkReferences" task failed unexpectedly.
         System.IO.FileNotFoundException: Could not load file or assembly 'NuGet.Frameworks' ...
     -->
-    <PackageReference Include="Nuget.ProjectModel" Version="$(NugetProjectModelVersion)" />
+    <PackageReference Include="Nuget.ProjectModel" Version="$(NugetProjectModelVersion)">
+      <IncludeAssets>build; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/hotreload-delta-gen/src/hotreload-delta-gen.csproj
+++ b/src/hotreload-delta-gen/src/hotreload-delta-gen.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bump to newer Arcade.
Bump to much newer MSBuild Locator
Build everything as .NET 6.
Don't include Nuget.ProjectModel runtime assets in standalone package - they should come from the same SDK as msbuild.

This fixes building the hot reload samples as of dotnet/runtime@f7308f03ed0