### PR TITLE
DeltaGeneratorTask works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100-preview.1.21103.13
+        dotnet-version: 6.0.100-preview.2.21155.3
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
-#    - name: Test
-#      run: dotnet test --no-restore --verbosity normal
+      run: dotnet build -c Release --no-restore
+    - name: Build(publish) standalone binary
+      run: dotnet publish -c Release --self-contained -r linux-x64
+    - name: Test example
+      run: cd src/hotreload-delta-gen/example && dotnet build -c Debug -p:ToolConfiguration=Release -p:ToolRid=linux-x64

--- a/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/DeltaGeneratorTask.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/DeltaGeneratorTask.cs
@@ -1,37 +1,113 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.HotReload.Utils
 {
-    public class DeltaGeneratorTask : Task
+    public class DeltaGeneratorTask : ToolTask
     {
         [Required]
         public string? ScriptPath { get; set; }
-        [Output]
+
+        [Required]
+        public string? ProjectFile {get ; set; }
+
+        /// Additional msbuild properties to pass to hotreload-delta-gen
+        ///  in Key=Value form
+        public string[]? BuildProperties {get; set;}
+
+        protected override string ToolName {
+            get => "hotreload-delta-gen";
+        }
 
         /// Each item is a full path of the generated dmeta file
         /// and has metadata DeltaIL and DeltaPDB with the full paths of the dmeta and dpdb files.
+        [Output]
         public ITaskItem[]? GeneratedDeltas { get; set; }
-        public override bool Execute()
-        {
-            if (ScriptPath is not string p) {
+
+        /// (Optional)
+        /// If set, the results will be written to the given json file.
+        /// If not set, a temporary file will be used
+        public string? OutputSummaryPath { get; set; }
+
+        protected override bool ValidateParameters() {
+            if (ScriptPath is not string script) {
                 Log.LogError ("no ScriptPath");
                 return false;
             }
-            if (!System.IO.File.Exists(p)) {
-                Log.LogError ($"script file {p} does not exist");
+            if (!System.IO.File.Exists(script)) {
+                Log.LogError ($"script file {script} does not exist");
                 return false;
             }
+            if (ProjectFile is not string proj) {
+                Log.LogError ("no ProjectFile");
+                return false;
+            }
+            if (!System.IO.File.Exists(proj)) {
+                Log.LogError ($"project file {proj} does not exist");
+                return false;
+            }
+            return true;
+        }
 
-            var items = new ITaskItem[1];
-            items[0] = new TaskItem("/tmp/Foo.0.dmeta", new Dictionary<string,string> {
-                { "DeltaIL", "/tmp/Foo.0.dil"},
-                { "DeltaPDB", "/tmp/Foo.0.dpdb"}
-            });
+        private string computedOutputSummaryPath = "";
+
+        public override bool Execute()
+        {
+            bool temporary = false;
+            if (OutputSummaryPath is string s)
+                computedOutputSummaryPath = s;
+            else {
+                computedOutputSummaryPath = System.IO.Path.GetTempFileName();
+                temporary = true;
+            }
+            ITaskItem[] items;
+            try {
+                if (!base.Execute())
+                    return false;
+                if (ExitCode != 0)
+                    return false;
+                items = ReadSummary (computedOutputSummaryPath).Result;
+            } finally {
+                if (temporary)
+                    DeleteTempFile(computedOutputSummaryPath);
+            }
 
             GeneratedDeltas = items;
             return true;
+        }
+
+        private static async Task<ITaskItem[]> ReadSummary (string summaryPath) {
+            using var stream = System.IO.File.OpenRead(summaryPath);
+            var json = await System.Text.Json.JsonSerializer.DeserializeAsync<OutputSummary.OutputSummary>(stream);
+            var deltas = json?.Deltas;
+            var n = deltas?.Length ?? 0;
+            var u = new ITaskItem[n];
+            for (int i = 0; i < n; ++i) {
+                var x = deltas?[i]!;
+                u[i] = new TaskItem(x.Metadata, new Dictionary<string,string> {
+                    {"Assembly", x.Assembly!},
+                    { "DeltaIL", x.IL!},
+                    { "DeltaPDB", x.PDB!}
+                });
+            }
+            return u;
+        }
+
+        protected override string GenerateFullPathToTool() => null!;
+        protected override string GenerateCommandLineCommands()
+        {
+            var builder = new CommandLineBuilder();
+            builder.AppendSwitchIfNotNull("-msbuild:", ProjectFile);
+            builder.AppendSwitchIfNotNull("-script:", ScriptPath);
+            builder.AppendSwitchIfNotNull("-outputSummary:", computedOutputSummaryPath);
+            if (BuildProperties is string[] props) {
+                foreach (var p in props) {
+                    builder.AppendSwitchIfNotNull("-p:", p);
+                }
+            }
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/OutputSummary.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask/OutputSummary.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DotNet.HotReload.Utils.OutputSummary {
+    public class OutputSummary {
+        [JsonPropertyName("deltas")]
+        public Delta[]? Deltas {get; set; }
+        [JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, object>? Extra {get; set;}
+    }
+
+    public class Delta {
+        [JsonPropertyName("assembly")]
+        public string? Assembly {get; set;}
+
+        [JsonPropertyName("metadata")]
+        public string? Metadata {get; set; }
+
+        [JsonPropertyName("il")]
+        public string? IL {get; set;}
+
+        [JsonPropertyName("pdb")]
+        public string? PDB {get; set;}
+
+        [JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, object>? Extra {get; set;}
+    }
+}

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
             public string ProjectPath {get; set; } = "";
 
             public string ScriptPath {get; set; } = "";
+
+            public string OutputSummaryPath {get; set; } = "";
             public Config Bake () {
                 return new MsbuildConfig(this);
             }
@@ -30,6 +32,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
             Properties = builder.Properties;
             ProjectPath = builder.ProjectPath;
             ScriptPath = builder.ScriptPath;
+            OutputSummaryPath = builder.OutputSummaryPath;
         }
 
         public bool Live { get; }
@@ -47,7 +50,11 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
         /// the directory to watch for live changes
         public string LiveCodingWatchDir { get => Path.GetDirectoryName(ProjectPath) ?? "."; }
 
+        /// the path of a JSON script to drive the delta generation
         public string ScriptPath { get; }
+
+        /// A path for a JSON file to collect the produced artifacts
+        public string OutputSummaryPath { get; }
     }
 
     internal class MsbuildConfig : Config {

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
     public class Config
     {
 
-        public static ConfigBuilder Builder () => new ConfigBuilder ();
+        public static ConfigBuilder Builder () => new ();
 
         public class ConfigBuilder {
             internal ConfigBuilder () {}

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/OutputSummary/OutputSummary.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/OutputSummary/OutputSummary.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Text.Json.Serialization;
+
+
+namespace Microsoft.DotNet.HotReload.Utils.Generator.OutputSummary
+{
+    public class OutputSummary {
+        [JsonPropertyName("deltas")]
+        public Delta[] Deltas {get; }
+
+        public OutputSummary(Delta[] deltas) {
+            Deltas = deltas;
+        }
+    }
+
+    public class Delta {
+        [JsonPropertyName("assembly")]
+        public string Assembly {get; }
+        [JsonPropertyName("metadata")]
+        public string Metadata {get; }
+        [JsonPropertyName("il")]
+        public string IL {get; }
+        [JsonPropertyName("pdb")]
+        public string Pdb {get; }
+
+        public Delta (string assembly, string metadata, string il, string pdb) {
+            Assembly = assembly;
+            Metadata = metadata;
+            IL = il;
+            Pdb = pdb;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
@@ -17,8 +17,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
             else
                 return new Runners.ScriptRunner (config);
         }
-        public async Task Run (CancellationToken ct = default(CancellationToken)) {
-            var baselineArtifacts = await SetupBaseline ();
+        public async Task Run (CancellationToken ct = default) {
+            var baselineArtifacts = await SetupBaseline (ct);
 
             var deltaProject = new DeltaProject (baselineArtifacts);
             var derivedInputs = SetupDeltas (baselineArtifacts, ct);

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
 
         public async Task GenerateDeltas (DeltaProject deltaProject, IAsyncEnumerable<Delta> deltas,
                                           Func<DeltaNaming,DeltaOutputStreams>? makeOutputs = null,
-                                          Action<DeltaOutputStreams>? outputsReady = null,
+                                          Action<DeltaNaming, DeltaOutputStreams>? outputsReady = null,
                                           CancellationToken ct =  default)
         {
             await foreach (var delta in deltas.WithCancellation(ct)) {

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
@@ -23,13 +23,21 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
             var deltaProject = new DeltaProject (baselineArtifacts);
             var derivedInputs = SetupDeltas (baselineArtifacts);
 
-            await GenerateDeltas (deltaProject, derivedInputs);
+            await GenerateDeltas (deltaProject, derivedInputs, makeOutputs: MakeOutputs, outputsReady: OutputsReady, ct: default(CancellationToken));
         }
 
         readonly protected Config config;
         protected Runner (Config config) {
             this.config = config;
         }
+
+        /// Delegate that is called to create the delta output streams.
+        /// If not set, a default is used that writes the deltas to files.
+        protected  Func<DeltaNaming,DeltaOutputStreams>? MakeOutputs {get; } = null;
+
+        /// Delegate that is called after the outputs have been emitted.
+        /// If not set, a default is used that does nothing.
+        protected  Action<DeltaNaming,DeltaOutputStreams>? OutputsReady {get; } = null;
 
         public async Task<BaselineArtifacts> SetupBaseline (CancellationToken ct = default) {
             BaselineProject? baselineProject;

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Runners
 
         private class JsonSummaryWriter {
             private string OutputPath {get; }
-            private List<OutputSummary.Delta> deltas;
+            private readonly List<OutputSummary.Delta> deltas;
             public JsonSummaryWriter(string outputPath) {
                 OutputPath = outputPath;
                 deltas = new List<OutputSummary.Delta>();
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Runners
                 deltas.Add(new OutputSummary.Delta("", names.Dmeta, names.Dil, names.Dpdb));
             }
 
-            internal async Task OutputsDone(CancellationToken ct = default(CancellationToken)) {
+            internal async Task OutputsDone(CancellationToken ct = default) {
                 using var s = File.OpenWrite(OutputPath);
                 var summary = new OutputSummary.OutputSummary(deltas.ToArray());
                 await System.Text.Json.JsonSerializer.SerializeAsync(s, summary, cancellationToken: ct);

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
@@ -12,8 +13,33 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Runners
     /// Generate deltas by reading a script from a configuration file
     /// listing the changed versions of the project source files.
     public class ScriptRunner : Runner {
-        public ScriptRunner (Config config) : base (config) { }
+        public ScriptRunner (Config config) : base (config) {
+            if (!string.IsNullOrEmpty(config.OutputSummaryPath)) {
+                var writer = new JsonSummaryWriter(config.OutputSummaryPath);
+                OutputsReady = writer.OutputsReady;
+                OutputsDone = writer.OutputsDone;
+            }
+        }
 
+        private class JsonSummaryWriter {
+            private string OutputPath {get; }
+            private List<OutputSummary.Delta> deltas;
+            public JsonSummaryWriter(string outputPath) {
+                OutputPath = outputPath;
+                deltas = new List<OutputSummary.Delta>();
+            }
+            internal void OutputsReady(DeltaNaming names, DeltaOutputStreams _streams) {
+                // FIXME: propagate the name of the updated assembly
+                deltas.Add(new OutputSummary.Delta("", names.Dmeta, names.Dil, names.Dpdb));
+            }
+
+            internal async Task OutputsDone(CancellationToken ct = default(CancellationToken)) {
+                using var s = File.OpenWrite(OutputPath);
+                var summary = new OutputSummary.OutputSummary(deltas.ToArray());
+                await System.Text.Json.JsonSerializer.SerializeAsync(s, summary, cancellationToken: ct);
+            }
+
+        }
 
         public override IAsyncEnumerable<Delta> SetupDeltas (BaselineArtifacts baselineArtifacts, CancellationToken ct = default)
         {

--- a/src/hotreload-delta-gen/example/TestClass.csproj
+++ b/src/hotreload-delta-gen/example/TestClass.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>library</OutputType>
         <EnableDefaultItems>false</EnableDefaultItems>
     </PropertyGroup>
@@ -8,4 +8,32 @@
         <Compile Include="TestClass.cs"/>
         <None Include="diffscript.json" />
     </ItemGroup>
+
+    <!-- find the hot reload artifacts from this repo -->
+    <PropertyGroup>
+        <ToolConfiguration Condition="'$(ToolConfiguration)'==''">$(Configuration)</ToolConfiguration>
+        <ToolTargetFramework Condition="'$(ToolTargetFramework)'==''">$(TargetFramework)</ToolTargetFramework>
+        <ToolRid Condition="'$(ToolRid)' == ''">osx-x64</ToolRid>
+        <HotReloadToolPath>$(OutputPath)\..\..\hotreload-delta-gen\$(ToolConfiguration)\$(ToolTargetFramework)\$(ToolRid)\publish</HotReloadToolPath>
+        <HotReloadTaskPath>$(OutputPath)\..\..\Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask\$(ToolConfiguration)\$(ToolTargetFramework)\Microsoft.DotNet.HotReload.Utils.DeltaGeneratorTask.dll</HotReloadTaskPath>
+    </PropertyGroup>
+
+    <UsingTask TaskName="DeltaGeneratorTask" AssemblyFile="$(HotReloadTaskPath)"/>
+
+    <Target Name="RunDiff" AfterTargets="Build">
+        <Message Importance="High" Text="Hi" />
+        <ItemGroup>
+          <ChildProps Include="Configuration=$(Configuration)" />
+        </ItemGroup>
+        <DeltaGeneratorTask
+            ToolPath="$(HotReloadToolPath)"
+            ScriptPath="$(MSBuildProjectDirectory)\diffscript.json"
+            ProjectFile="$(MSBuildProjectFullPath)"
+            BuildProperties="@(ChildProps)"
+            OutputSummaryPath="$(OutputPath)\result.json" >
+            <Output TaskParameter="GeneratedDeltas" ItemName="GeneratedDeltas"/>
+        </DeltaGeneratorTask>
+        <Message Importance="High" Text="Generated Deltas: @(GeneratedDeltas)" />
+    </Target>
+
 </Project>

--- a/src/hotreload-delta-gen/src/hotreload-delta-gen/Program.cs
+++ b/src/hotreload-delta-gen/src/hotreload-delta-gen/Program.cs
@@ -45,8 +45,8 @@ namespace RoslynILDiff
 
 
 
-        private static void PrintUsage(){
-            Console.WriteLine("hotreload-delta-gen.exe -msbuild:project.csproj [-p:Key=Value ...] [-live|-script:script.json]");
+        private static void PrintUsage() {
+            Console.WriteLine("hotreload-delta-gen.exe -msbuild:project.csproj [-p:Key=Value ...] [-live|-script:script.json [-outputSummary:results.json]]");
         }
         static bool ParseArgs (string[] args, [NotNullWhen(true)] out Microsoft.DotNet.HotReload.Utils.Generator.Config? config)
         {
@@ -58,6 +58,7 @@ namespace RoslynILDiff
             for (int i = 0; i < args.Length; i++) {
                 const string msbuildOptPrefix = "-msbuild:";
                 const string scriptOptPrefix = "-script:";
+                const string outputSummaryPrefix = "-outputSummary:";
                 string fn = args [i];
                 if (fn.StartsWith(msbuildOptPrefix)) {
                     builder.ProjectPath = fn[msbuildOptPrefix.Length..];
@@ -77,6 +78,8 @@ namespace RoslynILDiff
                     }
                 } else if (fn.StartsWith(scriptOptPrefix)) {
                     builder.ScriptPath = fn[scriptOptPrefix.Length..];
+                } else if (fn.StartsWith(outputSummaryPrefix)) {
+                    builder.OutputSummaryPath = fn[outputSummaryPrefix.Length..];
                 } else {
                     PrintUsage();
                     Console.WriteLine ($"\tUnexpected trailing option {fn}");
@@ -94,6 +97,11 @@ namespace RoslynILDiff
                 PrintUsage();
                 Console.WriteLine("\tExactly one of -live or -script:script.json is required");
                 return false;
+            }
+
+            if (builder.Live && !String.IsNullOrEmpty(builder.OutputSummaryPath)) {
+                PrintUsage();
+                Console.WriteLine ("-outputSummary and -live cannot be used at the same time");
             }
 
             config = builder.Bake();


### PR DESCRIPTION
Extend `hotreload-delta-gen` with a new `-outputSummary:results.json`  option that writes the names of the generated artifacts to a json file.

Change `DeltaGeneratorTask` to an MSBuild ToolTask that invokes `hotreload-delta-gen`, collects a summary, and populates a `GeneratedDeltas` MSBuild Item with the artifacts.  Each item's Identity is the metadata delta, and its `DeltaIL` and `DeltaPDB` msbuild metadata properties are the full paths of the dil and dpdb files.

Also update `src/hotreload-delta-gen/example` to invoke the task.  So a simple `dotnet build` in that directory will build the baseline and also build the deltas.