### PR TITLE
Add some tests for Generator.BuildTool

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,5 +15,21 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>5faea1b7965644d1f1c666a7130f6f614abe76c0</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21257.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>5faea1b7965644d1f1c666a7130f6f614abe76c0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.21257.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>5faea1b7965644d1f1c666a7130f6f614abe76c0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.21257.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>5faea1b7965644d1f1c666a7130f6f614abe76c0</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201201-01">
+      <Uri>https://github.com/microsoft/vstest</Uri>
+      <Sha>140434f7109d357d0158ade9e5164a4861513965</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,15 @@
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.1</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>3.9.0-5.21120.8</MicrosoftCodeAnalysisVersion>
+    <!-- Testing -->
+    <MicrosoftNETTestSdkVersion>16.9.0-preview-20201201-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21257.5</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21257.5</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21257.5</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
+    <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
+    <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
+    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <!--
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.

--- a/hotreload-utils.proj
+++ b/hotreload-utils.proj
@@ -6,5 +6,7 @@
     <ProjectReference Include="src/hotreload-delta-gen/src/hotreload-delta-gen.csproj" />
     <ProjectReference Include="src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" />
     <ProjectReference Include="src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" />
+
+    <ProjectReference Include="tests\**\*.*proj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
@@ -5,16 +5,17 @@
     <!-- If DotNetTool is undefined, we default to assuming 'dotnet' is on the path -->
     <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
 
-    <_HotReloadDeltaGeneratorPath>$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 
     <_HotReloadDeltaGeneratorCommand>$(DotNetTool) $(_HotReloadDeltaGeneratorPath)</_HotReloadDeltaGeneratorCommand>
 
-    <_HotReloadDeltaGeneratorTasksPath>$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
 
   <PropertyGroup>
     <_HotReloadDeltaGeneratorDeltaScript Condition="'$(DeltaScript)' != ''">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), '$(DeltaScript)'))</_HotReloadDeltaGeneratorDeltaScript>
     <_HotReloadDeltaGeneratorShouldRun Condition="'$(_HotReloadDeltaGeneratorShouldRun)' == '' and Exists('$(_HotReloadDeltaGeneratorDeltaScript)')">true</_HotReloadDeltaGeneratorShouldRun>
+    <_HotReloadDeltaGeneratorShouldRun Condition="'$(_HotReloadDeltaGeneratorShouldRun)' == ''">false</_HotReloadDeltaGeneratorShouldRun>
   </PropertyGroup>
 
 

--- a/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
@@ -5,16 +5,7 @@
     <!-- NOTE: no DeltaScript property - importing the BuildTool.targets should have no effect -->
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
-  </ItemGroup>
+  <Import Project="..\ImportExplicitly.props" />
 
-  <!-- explicitly set tool path -->
-  <PropertyGroup>
-    <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
-    <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
-  </PropertyGroup>
-
-  <Import Project="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets" />
+  <Import Project="$(InTreeGeneratorBuildToolTargetsPath)" />
 </Project>

--- a/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- NOTE: no DeltaScript property - importing the BuildTool.targets should have no effect -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- explicitly set tool path -->
+  <PropertyGroup>
+    <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets" />
+</Project>

--- a/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.cs
+++ b/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using Xunit;
+
+using AssemblyExtensions = System.Reflection.Metadata.AssemblyExtensions;
+
+namespace ImportExplicitly.ShouldNotRun.Tests
+{
+    public class ImportExplicitlyShouldNotRun
+    {
+        [Fact]
+        public void NoGeneratedDeltas()
+        {
+            // Check that the delta generator did not run - there should be no .dmeta files next to the assembly
+
+            var path = Path.GetDirectoryName(typeof(ImportExplicitlyShouldNotRun).Assembly.Location);
+            var metadataDeltas = Directory.GetFiles(path, "*.dmeta");
+            Assert.Empty(metadataDeltas);
+        }
+
+    }
+}

--- a/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
+    <Optimize>false</Optimize>
+    <EmitDebugInformation>true</EmitDebugInformation>
+    <DeltaScript>delta.json</DeltaScript>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- explicitly set tool path -->
+  <PropertyGroup>
+    <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+  </PropertyGroup>
+
+  <Target Name="PrintConfig" BeforeTargets="CoreCompile">
+    <Message Importance="High" Text="Hot Reload Generator Path is $(_HotReloadDeltaGeneratorPath)" />
+  </Target>
+
+  <Import Project="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets" />
+</Project>

--- a/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
@@ -12,20 +12,7 @@
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
-  </ItemGroup>
+  <Import Project="..\ImportExplicitly.props" />
 
-  <!-- explicitly set tool path -->
-  <PropertyGroup>
-    <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
-    <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
-  </PropertyGroup>
-
-  <Target Name="PrintConfig" BeforeTargets="CoreCompile">
-    <Message Importance="High" Text="Hot Reload Generator Path is $(_HotReloadDeltaGeneratorPath)" />
-  </Target>
-
-  <Import Project="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets" />
+  <Import Project="$(InTreeGeneratorBuildToolTargetsPath)" />
 </Project>

--- a/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.cs
+++ b/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using Xunit;
+using Microsoft.DotNet.RemoteExecutor;
+
+using AssemblyExtensions = System.Reflection.Metadata.AssemblyExtensions;
+
+namespace ImportExplicitly.Tests
+{
+    // FIXME: CollectionDefinition RunInParallel false
+    public class ImportExplicitly
+    {
+        [Fact]
+        public void TestDeltaExists()
+        {
+            // In Release configurations we can only check that the tool created the files
+            var path = typeof(ImportExplicitly).Assembly.Location;
+            Assert.True(File.Exists(path + ".1.dmeta"));
+            Assert.True(File.Exists(path + ".1.dil"));
+        }
+
+        [Fact]
+        public void TestGoodDelta()
+        {
+            // In a Debug configuration, we can try to apply the delta, if the right environment is set
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.Environment.Add ("DOTNET_MODIFIABLE_ASSEMBLIES", "Debug");
+
+            RemoteExecutor.Invoke(static () =>
+            {
+                string s = TargetClass.TargetMethod();
+
+                Assert.Equal("OLD", s);
+
+                ApplyUpdate();
+
+                s = TargetClass.TargetMethod ();
+
+                Assert.Equal("NEW", s);
+            }, options).Dispose();
+        }
+
+        internal static void ApplyUpdate()
+        {
+            var path = typeof(ImportExplicitly).Assembly.Location;
+            var dmeta = File.ReadAllBytes(path + ".1.dmeta");
+            var dil = File.ReadAllBytes(path + ".1.dil");
+            AssemblyExtensions.ApplyUpdate (typeof(ImportExplicitly).Assembly, dmeta, dil, ReadOnlySpan<byte>.Empty);
+        }
+    }
+}

--- a/tests/BuildTool/ImportExplcitly.Tests/TargetClass.cs
+++ b/tests/BuildTool/ImportExplcitly.Tests/TargetClass.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ImportExplicitly.Tests
+{
+    public static class TargetClass
+    {
+        public static string TargetMethod ()
+        {
+            return "OLD";
+        }
+    }
+}

--- a/tests/BuildTool/ImportExplcitly.Tests/TargetClass.cs.v1
+++ b/tests/BuildTool/ImportExplcitly.Tests/TargetClass.cs.v1
@@ -1,0 +1,12 @@
+using System;
+
+namespace ImportExplicitly.Tests
+{
+    public static class TargetClass
+    {
+        public static string TargetMethod ()
+        {
+            return "NEW";
+        }
+    }
+}

--- a/tests/BuildTool/ImportExplcitly.Tests/delta.json
+++ b/tests/BuildTool/ImportExplcitly.Tests/delta.json
@@ -1,0 +1,5 @@
+{
+    "changes": [
+        { "document": "TargetClass.cs", "update": "TargetClass.cs.v1" }
+    ]
+}

--- a/tests/BuildTool/ImportExplicitly.props
+++ b/tests/BuildTool/ImportExplicitly.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <!-- Set the paths for the generator buildtool and tasks assemblies explicitly so that we can Import the in-tree BuildTool.targets file -->
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- explicitly set tool path -->
+  <PropertyGroup>
+    <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <InTreeGeneratorBuildToolTargetsPath>$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</InTreeGeneratorBuildToolTargetsPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Explicitly provide paths to the build tool and tasks assemblies, and verify that including the BuildTool.targets file will cause the tools
to execute (if a DeltaScript property is present) or not (if it isn't).

Uses the AssemblyExtensions.ApplyUpdate API from .NET 6 Preview 3 or later.