### PR TITLE
Roslyn bump: Use new Roslyn AnalyzeDocumentsAsync capabilities, EditSession APIs 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,9 +5,12 @@
   </solution>
   <packageSources>
     <clear />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.CodeAnalysis" Version="3.9.0-5.21120.8">
+    <Dependency Name="Microsoft.CodeAnalysis" Version="4.0.0-2.21260.14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>accdcb77007e801eabcb2c221bad9ef837b64ee3</Sha>
+      <Sha>a1f236a026e729cc6bcf2e207085a9d562cb732c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="3.3.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Libs -->
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.1</MicrosoftCodeAnalysisAnalyzersVersion>
-    <MicrosoftCodeAnalysisVersion>3.9.0-5.21120.8</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.0-2.21260.14</MicrosoftCodeAnalysisVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.9.0-preview-20201201-01</MicrosoftNETTestSdkVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21257.5</MicrosoftDotNetRemoteExecutorVersion>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
@@ -23,16 +23,26 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
         private const string csharpCodeAnalyzerTypeName = "Microsoft.CodeAnalysis.CSharp.EditAndContinue.CSharpEditAndContinueAnalyzer";
         private const string activeStatementTypeName = "Microsoft.CodeAnalysis.EditAndContinue.ActiveStatement";
 
-        private readonly Type _codeAnalyzer;
-        private readonly Type _activeStatement;
+        private const string capabilitiesTypeName = "Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueCapabilities";
+
+        private const string editSessionTypeName = "Microsoft.CodeAnalysis.EditAndContinue.EditSession";
+
+        struct Reflected {
+            internal Type _codeAnalyzer {get; init;}
+            internal readonly Type _activeStatement {get; init;}
+
+            internal readonly Type _capabilities {get; init;}
+
+            internal readonly Type _editSession {get; init;}
+        }
+
+        private readonly Reflected _reflected;
 
         public ChangeMaker () {
-            var (codeAnalyzer, activeStatement) = ReflectionInit();
-            _codeAnalyzer = codeAnalyzer;
-            _activeStatement = activeStatement;
+            _reflected = ReflectionInit();
         }
         // Get all the Roslyn stuff we need
-        private static (Type codeAnalyzer, Type activeStatement) ReflectionInit ()
+        private static Reflected ReflectionInit ()
         {
             var an = new AssemblyName (csharpCodeAnalysisAssemblyName);
             var assm = AssemblyLoadContext.Default.LoadFromAssemblyName(an)!;
@@ -48,10 +58,43 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
             if (actS == null) {
                 throw new Exception ("Coudln't find ActiveStatement type");
             }
-            return (codeAnalyzer: ca, activeStatement: actS);
+
+            var caps = assm.GetType (capabilitiesTypeName);
+
+            if (caps == null) {
+                throw new Exception ("Couldn't find EditAndContinueCapabilities type");
+            }
+
+            var editSess = assm.GetType (editSessionTypeName);
+
+            if (editSess == null) {
+                throw new Exception ("Couldn't find EditSession type");
+            }
+
+            return new Reflected() { _codeAnalyzer =  ca,
+                                    _activeStatement =  actS,
+                                    _capabilities =  caps,
+                                    _editSession = editSess
+                                    };
         }
 
-        public Task<(ImmutableArray<SemanticEdit>, ImmutableArray<RudeEditDiagnosticWrapper>)> GetChanges(Document oldDocument, Document newDocument, CancellationToken cancellationToken = default)
+        /// Convert my EditAndContinueCapabilities enum value to
+        ///  [Microsoft.CodeAnalysis.Features]Microsoft.CodeAnalysis.EditAndContinue.EditAndContinueCapabilities
+        private object ConvertCapabilities (EditAndContinueCapabilities myCaps)
+        {
+            int i = (int)myCaps;
+            object theirCaps = Enum.ToObject(_reflected._capabilities, i);
+            return theirCaps;
+        }
+
+        private object DefaultEditAndContinueCapabilities()
+        {
+            var myCaps = EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.AddMethodToExistingType
+                | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType
+                | EditAndContinueCapabilities.NewTypeDefinition;
+            return ConvertCapabilities(myCaps);
+        }
+        public Task<(DocumentAnalysisResultsWrapper, ImmutableArray<RudeEditDiagnosticWrapper>)> GetChanges(Project oldProject, Document newDocument, CancellationToken cancellationToken = default)
         {
             // Effectively
             //
@@ -59,29 +102,32 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
             //      var analyzer = new CSharpEditAndContinueAnalyzer (null);
             //      var activeStatements = ImmutableArray.Create<ActiveStatement>();
             //      var textSpans = ImmutableArray.Create<TextSpan>();
-            //      var result = await analyzer.AnalyzeDocumentAsync (oldDocument, activeStatements, newDocument, textSpans, cancellationToken);
+            //      var capabilities = DefaultEditAndContinueCapabilities ();
+            //      var result = await analyzer.AnalyzeDocumentAsync (oldDocument, activeStatements, newDocument, textSpans, capabilities, cancellationToken);
             //      var edits = result.SemanticEdits;
-            //      var rudeEdits = result.RudeEditErrorss;
+            //      var rudeEdits = result.RudeEditErrors;
             //      return (edits, rudeEdits);
             // }
             //
-            var analyzer = Activator.CreateInstance(_codeAnalyzer, new object?[]{null});
+            var analyzer = Activator.CreateInstance(_reflected._codeAnalyzer, new object?[]{null});
 
-            var makeEmptyImmutableArray = typeof(ImmutableArray).GetMethod("Create", 1, Array.Empty<Type>())!.MakeGenericMethod(new Type[] {_activeStatement});
+            var makeEmptyImmutableArray = typeof(ImmutableArray).GetMethod("Create", 1, Array.Empty<Type>())!.MakeGenericMethod(new Type[] {_reflected._activeStatement});
             var activeStatements = makeEmptyImmutableArray.Invoke(null, Array.Empty<object>())!;
-            var mi = _codeAnalyzer.GetMethod("AnalyzeDocumentAsync")!;
+            var mi = _reflected._codeAnalyzer.GetMethod("AnalyzeDocumentAsync")!;
 
             var textSpans = ImmutableArray.Create<TextSpan>();
 
-            var taskResult = mi.Invoke (analyzer, new object[] {oldDocument, activeStatements, newDocument, textSpans, cancellationToken});
+            var capabilities = DefaultEditAndContinueCapabilities();
+
+            var taskResult = mi.Invoke (analyzer, new object[] {oldProject, activeStatements, newDocument, textSpans, capabilities, cancellationToken});
 
             if (taskResult == null) {
                 throw new Exception("taskResult was null");
             }
 
             // We just want
-            //   taskResult.ContinueWith ((t) => t.Result.SemanticEdits);
-            // but then we'd need to make a Func<DocumentAnalysisResults, IEnumerable<SemanticEdit>>
+            //   taskResult.ContinueWith ((t) => (t.Result, t.Result.RudeEdits);
+            // but then we'd need to make a Func<DocumentAnalysisResults, IEnumerable<RudeEditErrors>>
             // and that's really annoying to do if you can't say the type name DocumentAnalysisResults
             //
             // So instead we do:
@@ -98,12 +144,14 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
 
             var awaiter = taskResult.GetType().GetMethod("GetAwaiter")!.Invoke(taskResult, Array.Empty<object>())!;
 
-            TaskCompletionSource<(ImmutableArray<SemanticEdit>, ImmutableArray<RudeEditDiagnosticWrapper>)> tcs = new ();
+            TaskCompletionSource<(DocumentAnalysisResultsWrapper, ImmutableArray<RudeEditDiagnosticWrapper>)> tcs = new ();
 
             Action onCompleted = delegate {
                 try {
+                    // Unable to cast object of type 'System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.EditAndContinue.SemanticEditInfo]'
+                    // to type 'System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.Emit.SemanticEdit]'
                     var result = awaiter.GetType().GetMethod("GetResult")!.Invoke(awaiter, Array.Empty<object>())!;
-                    var edits = (ImmutableArray<SemanticEdit>)result.GetType().GetProperty("SemanticEdits")!.GetValue(result)!;
+                    var wrappedResult = new DocumentAnalysisResultsWrapper(result);
 
                     // type is ImmutableArray<RudeEditDiagnostic>
                     var rudeEditErrors = (System.Collections.IEnumerable)result.GetType().GetProperty("RudeEditErrors")!.GetValue(result)!;
@@ -124,7 +172,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
                         var span = (TextSpan) spanFieldInfo.GetValue(rudeEditError)!;
                         rudeEdits.Add(new RudeEditDiagnosticWrapper(kind, span));
                     }
-                    tcs.TrySetResult((edits, rudeEdits.ToImmutableArray()));
+                    tcs.TrySetResult((wrappedResult, rudeEdits.ToImmutableArray()));
                 } catch (TaskCanceledException e) {
                     tcs.TrySetCanceled(e.CancellationToken);
                 } catch (Exception e) {
@@ -135,6 +183,58 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
             awaiter.GetType().GetMethod("OnCompleted")!.Invoke (awaiter, new object[] {onCompleted});
 
             return tcs.Task;
+        }
+
+
+        private static MethodInfo GetImmutableArrayCreateSingletonMethod () {
+            foreach (var mi in typeof(ImmutableArray).GetMethods(BindingFlags.Static|BindingFlags.Public)) {
+                if (mi.Name != "Create")
+                    continue;
+                if (mi.GetGenericArguments().Length != 1)
+                    continue;
+                var pars = mi.GetParameters();
+                if (pars.Length != 1)
+                    continue;
+                if (pars[0].ParameterType.IsArray)
+                    continue;
+                if (!pars[0].ParameterType.IsGenericParameter)
+                    continue;
+                return mi;
+            }
+            throw new Exception ("Could not find ImmutableArray.Create<T>(T arg)");
+        }
+
+        public object MakeSingleImmutableArrayDocumentAnalysisResults (DocumentAnalysisResultsWrapper w)
+        {
+            // ImmutableArray.Create<DocumentAnalsysisResult> (w.Underlying)
+            MethodInfo mi = GetImmutableArrayCreateSingletonMethod ();
+
+            var dar = w.Underlying;
+
+            return mi.MakeGenericMethod(dar.GetType()).Invoke(null, new object[] {dar});
+        }
+
+        public ImmutableArray<SemanticEdit> GetProjectChanges (Compilation oldCompilation, Compilation newCompilation, DocumentAnalysisResultsWrapper documentAnalysisResultsWrapper, CancellationToken ct = default)
+        {
+                var getProjectChangesMethod = _reflected._editSession.GetMethod("GetProjectChanges", BindingFlags.NonPublic | BindingFlags.Static);
+
+                object results = MakeSingleImmutableArrayDocumentAnalysisResults (documentAnalysisResultsWrapper);
+
+                var projectChanges = getProjectChangesMethod?.Invoke (null, new object[] {oldCompilation, newCompilation, results, ct});
+
+                if (projectChanges == null)
+                    return ImmutableArray.Create<SemanticEdit>();
+
+                var projectChangesType = projectChanges.GetType();
+
+                var fi = projectChangesType.GetField("SemanticEdits");
+
+                var edits = fi?.GetValue(projectChanges);
+
+                if (edits == null)
+                    return ImmutableArray.Create<SemanticEdit>();
+
+                return (ImmutableArray<SemanticEdit>)edits;
         }
     }
 }

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/DocumentAnalysisResultsWrapper.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/DocumentAnalysisResultsWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 
 namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
 {
@@ -5,13 +6,17 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
     /// Wraps a Microsoft.CodeAnalysis.EditAndContinue.DocumentAnalysisResults class
     public class DocumentAnalysisResultsWrapper
     {
-        public bool HasChanges { get; }
-        public bool HasSyntaxErrors { get; }
+        // FIXME: TODO: get the HasChanges value from the underlying
+        public bool HasChanges { get => throw new NotImplementedException (); }
+        // FIXME: TODO: get the HasSyntaxErrors value from the underlying
+        public bool HasSyntaxErrors { get => throw new NotImplementedException (); }
 
         public object Underlying {get; init;}
 
         public DocumentAnalysisResultsWrapper(object underlying) {
             Underlying = underlying;
         }
+
+
     }
 }

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/DocumentAnalysisResultsWrapper.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/DocumentAnalysisResultsWrapper.cs
@@ -1,0 +1,17 @@
+
+namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
+{
+
+    /// Wraps a Microsoft.CodeAnalysis.EditAndContinue.DocumentAnalysisResults class
+    public class DocumentAnalysisResultsWrapper
+    {
+        public bool HasChanges { get; }
+        public bool HasSyntaxErrors { get; }
+
+        public object Underlying {get; init;}
+
+        public DocumentAnalysisResultsWrapper(object underlying) {
+            Underlying = underlying;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/EditAndContinueCapabilities.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/EditAndContinueCapabilities.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
+{
+
+    /// Copied from https://github.com/dotnet/roslyn/blob/e8e6d30fe462edd48ce13f6438e91d26876c17bb/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
+    /// Keep in sync
+    /// <summary>
+    /// The capabilities that the runtime has with respect to edit and continue
+    /// </summary>
+    [Flags]
+    internal enum EditAndContinueCapabilities
+    {
+        None = 0,
+
+        /// <summary>
+        /// Edit and continue is generally available with the set of capabilities that Mono 6, .NET Framework and .NET 5 have in common.
+        /// </summary>
+        Baseline = 1 << 0,
+
+        /// <summary>
+        /// Adding a static or instance method to an existing type.
+        /// </summary>
+        AddMethodToExistingType = 1 << 1,
+
+        /// <summary>
+        /// Adding a static field to an existing type.
+        /// </summary>
+        AddStaticFieldToExistingType = 1 << 2,
+
+        /// <summary>
+        /// Adding an instance field to an existing type.
+        /// </summary>
+        AddInstanceFieldToExistingType = 1 << 3,
+
+        /// <summary>
+        /// Creating a new type definition.
+        /// </summary>
+        NewTypeDefinition = 1 << 4
+    }
+
+}


### PR DESCRIPTION
Bump to roslyn from the VS Master channel.

React to API changes:

- `AnalyzeDocumentsAsync` gained a new `EditAndContinueCapabilities` argument, and now takes the old `Project`, not the old `Document`
- `DocumentAnalysisResults.SemanticEdits` are now a collection of `SemanticEditInfo` which isn't directly usable by `EmitDifference`.
- Instead, there's a new `EditSession.GetProjectChanges` function that combines a collection of `DocumentAnalysisResults` with the old and new `Compilation` objects to give a collection of `SemanticEdit`s.
