### PR TITLE
Fix dotnet tool invocation on paths with spaces

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
@@ -5,11 +5,11 @@
     <!-- If DotNetTool is undefined, we default to assuming 'dotnet' is on the path -->
     <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
 
-    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 
-    <_HotReloadDeltaGeneratorCommand>$(DotNetTool) $(_HotReloadDeltaGeneratorPath)</_HotReloadDeltaGeneratorCommand>
+    <_HotReloadDeltaGeneratorCommand>"$(DotNetTool)" $(_HotReloadDeltaGeneratorPath)</_HotReloadDeltaGeneratorCommand>
 
-    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The DotNetTool command needs to be quoted otherwise the execution fails epically:

```
'C:\Program' is not recognized as an internal or external command,
  operable program or batch file.
```