### PR TITLE
Add acceptance test that checks EnC capability compatibility

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
@@ -38,6 +38,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
 
         private readonly Reflected _reflected;
 
+        public Type EditAncContinueCapabilitiesType => _reflected._capabilities;
+
         public ChangeMaker () {
             _reflected = ReflectionInit();
         }

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/EditAndContinueCapabilities.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/EditAndContinueCapabilities.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
     /// The capabilities that the runtime has with respect to edit and continue
     /// </summary>
     [Flags]
-    internal enum EditAndContinueCapabilities
+    public enum EditAndContinueCapabilities
     {
         None = 0,
 

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator\Microsoft.DotNet.HotReload.Utils.Generator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.cs
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Xunit;
+
+namespace EncCapabilitiesCompatTest {
+    public class EncCapabilitiesCompatTest {
+
+        public struct CapDescriptor {
+            public string Name;
+            public int Value;
+        }
+
+        static readonly Microsoft.DotNet.HotReload.Utils.Generator.EnC.ChangeMaker ChangeMaker = new ();
+
+        internal static IReadOnlyList<CapDescriptor> MakeDescriptor (Type ty) {
+            List<CapDescriptor> l = new ();
+            if (!ty.IsEnum) {
+                throw new Exception($"Type {ty} is not an enumeration");
+            }
+            var underlying = ty.GetEnumUnderlyingType();
+            if (underlying != typeof(int)) {
+                throw new Exception($"Underlying type of {ty} is {underlying}, not Int32");
+            }
+            foreach (var enumName in ty.GetEnumNames()) {
+                if (!Enum.TryParse(ty, enumName, out var v))
+                    throw new Exception ($"Could not get value of enumeration constant {enumName} of type {ty}");
+                if (v == null)
+                    throw new Exception ($"enumeration value of {ty}.{enumName} was null");
+                int intVal = (int)v;
+                l.Add (new CapDescriptor {Name = enumName, Value = intVal});
+            }
+            return l;
+        }
+
+        public static IReadOnlyList<CapDescriptor> GetGeneratorCapabilities() => MakeDescriptor(typeof(Microsoft.DotNet.HotReload.Utils.Generator.EnC.EditAndContinueCapabilities));
+        public static IReadOnlyList<CapDescriptor> GetRoslynCapabilities() => MakeDescriptor(ChangeMaker.EditAncContinueCapabilitiesType);
+
+        [Fact]
+        public static void SameCapabilities () {
+            // Check that roslyn and hotreload-utils have the same EnC capabilities defined.
+            // Should help to keep hotreload-utils up to date when Roslyn pushes changes.
+
+            IReadOnlyList<CapDescriptor> generatorCaps = GetGeneratorCapabilities();
+            IReadOnlyList<CapDescriptor> roslynCaps = GetRoslynCapabilities();
+
+            // TODO: Maybe collect all mismatches and just assert once at the end?
+            // Or use a [Theory] for each cap that compares it against the whole list from the other set
+            foreach (var roslynCap in roslynCaps) {
+                bool found = false;
+                foreach (var generatorCap in generatorCaps) {
+                    if (roslynCap.Name != generatorCap.Name)
+                        continue;
+                    found = true;
+                    Assert.True (roslynCap.Value == generatorCap.Value, $"Capability {roslynCap.Name} in Roslyn has value {roslynCap.Value} and {generatorCap.Value} in hotreload-utils.");
+                }
+                Assert.True (found, $"Capability {roslynCap.Name} in Roslyn with value {roslynCap.Value} not present in hotreload-utils");
+            }
+
+            foreach (var generatorCap in generatorCaps) {
+                bool found = false;
+                foreach (var roslynCap in roslynCaps) {
+                    if (roslynCap.Name == generatorCap.Name) {
+                        // if it's in both it has the same value, by the previous loop
+                        found = true;
+                        break;
+                    }
+                }
+                Assert.True (found, $"Capability {generatorCap.Name} in hotreload-utils with value {generatorCap.Value} not present in Roslyn");
+            }
+        }
+    }
+}


### PR DESCRIPTION

Check that Roslyn and hotreload-utils EnC capability definitions are in sync.

The goal is primarily to fail something when maestro pushes changes from Roslyn