### PR TITLE
Add ability to pass EnC capabilities on the command line

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Frontend/Frontend.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Frontend/Frontend.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Frontend
                 const string msbuildOptPrefix = "-msbuild:";
                 const string scriptOptPrefix = "-script:";
                 const string outputSummaryPrefix = "-outputSummary:";
+                const string capabilitiesPrefix = "-capabilities:";
                 string fn = args [i];
                 if (fn.StartsWith(msbuildOptPrefix)) {
                     builder.ProjectPath = fn[msbuildOptPrefix.Length..];
@@ -77,6 +78,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Frontend
                     builder.ScriptPath = fn[scriptOptPrefix.Length..];
                 } else if (fn.StartsWith(outputSummaryPrefix)) {
                     builder.OutputSummaryPath = fn[outputSummaryPrefix.Length..];
+                } else if (fn.StartsWith(capabilitiesPrefix)) {
+                    builder.EditAndContinueCapabilities.Add (fn[capabilitiesPrefix.Length..]);
                 } else {
                     PrintUsage();
                     Console.WriteLine ($"\tUnexpected trailing option {fn}");

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -26,6 +27,10 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
             public Config Bake () {
                 return new MsbuildConfig(this);
             }
+
+            public string[] EditAndContinueCapabilities {get; set; } = Array.Empty<string>();
+
+            public bool NoWarnUnknownCapabilities {get; set;} = false;
         }
 
         protected Config (ConfigBuilder builder) {
@@ -34,6 +39,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
             ProjectPath = builder.ProjectPath;
             ScriptPath = builder.ScriptPath;
             OutputSummaryPath = builder.OutputSummaryPath;
+            EditAndContinueCapabilities = builder.EditAndContinueCapabilities;
+            NoWarnUnknownCapabilities = builder.NoWarnUnknownCapabilities;
         }
 
         public bool Live { get; }
@@ -56,6 +63,12 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
 
         /// A path for a JSON file to collect the produced artifacts
         public string OutputSummaryPath { get; }
+
+        /// A set of strings specifying edit and continue capabilities to pass to Roslyn
+        public string[] EditAndContinueCapabilities { get; }
+
+        /// If 'true' don't print a warning if a capability is not known.
+        public bool NoWarnUnknownCapabilities {get; }
     }
 
     internal class MsbuildConfig : Config {

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Config.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
                 return new MsbuildConfig(this);
             }
 
-            public string[] EditAndContinueCapabilities {get; set; } = Array.Empty<string>();
+            public List<string> EditAndContinueCapabilities {get; set; } = new List<string>();
 
             public bool NoWarnUnknownCapabilities {get; set;} = false;
         }
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
             ProjectPath = builder.ProjectPath;
             ScriptPath = builder.ScriptPath;
             OutputSummaryPath = builder.OutputSummaryPath;
-            EditAndContinueCapabilities = builder.EditAndContinueCapabilities;
+            EditAndContinueCapabilities = builder.EditAndContinueCapabilities.ToArray();
             NoWarnUnknownCapabilities = builder.NoWarnUnknownCapabilities;
         }
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
     public class DeltaProject
     {
         readonly EnC.ChangeMaker _changeMaker;
+        readonly EnC.EditAndContinueCapabilities _capabilities;
 
         readonly Solution _solution;
         readonly EmitBaseline _baseline;
@@ -28,17 +29,19 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
 
         readonly DeltaNaming _nextName;
 
-        public DeltaProject(BaselineArtifacts artifacts) {
+        public DeltaProject(BaselineArtifacts artifacts, EnC.EditAndContinueCapabilities capabilities) {
             _changeMaker = new EnC.ChangeMaker();
             _solution = artifacts.baselineSolution;
             _baseline = artifacts.emitBaseline;
             _baseProjectId = artifacts.baselineProjectId;
             _nextName = new DeltaNaming(artifacts.baselineOutputAsmPath, 1);
+            _capabilities = capabilities;
         }
 
         internal DeltaProject (DeltaProject prev, Solution newSolution, EmitBaseline newBaseline)
         {
             _changeMaker = prev._changeMaker;
+            _capabilities = prev._capabilities;
             _solution = newSolution;
             _baseline = newBaseline;
             _baseProjectId = prev._baseProjectId;
@@ -50,6 +53,8 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
         public EmitBaseline Baseline => _baseline;
 
         public ProjectId BaseProjectId => _baseProjectId;
+
+        public EnC.EditAndContinueCapabilities EditAndContinueCapabilities => _capabilities;
 
         /// The default output function
         ///  Creates files with the specified DeltaNaming without any other side-effects
@@ -149,7 +154,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
 
         Task<(EnC.DocumentAnalysisResultsWrapper, ImmutableArray<EnC.RudeEditDiagnosticWrapper>)> CompileEdits (Project project, Document updatedDocument, CancellationToken ct = default)
         {
-            return _changeMaker.GetChanges(project, updatedDocument, ct);
+            return _changeMaker.GetChanges(_capabilities, project, updatedDocument, ct);
         }
 
         ImmutableArray<SemanticEdit> GetProjectChanges (Compilation oldCompilation, Compilation newCompilation, EnC.DocumentAnalysisResultsWrapper results, CancellationToken ct = default)

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EditAndContinueCapabilitiesParser.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EditAndContinueCapabilitiesParser.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.HotReload.Utils.Generator
+{
+    public static class EditAndContinueCapabilitiesParser {
+
+        public readonly struct Token {
+            public readonly string Value {get; init;}
+        }
+        static public Regex capabilitiesTokenizer = new Regex(@"^\s*(?:(\S+)\s+)*(\S+)?$", RegexOptions.CultureInvariant);
+        public static IEnumerable<Token> Tokenize (string capabilities)
+        {
+            Match match = capabilitiesTokenizer.Match (capabilities);
+            if (!match.Success)
+                yield break;
+            foreach (Capture c in match.Groups[1].Captures) {
+                        yield return new Token { Value = c.Value };
+            }
+            foreach (Capture c in match.Groups[2].Captures) {
+                yield return new Token { Value = c.Value };
+            }
+        }
+
+        public static IEnumerable<Token> Tokenize (IEnumerable<string> capabilities)
+        {
+            foreach (var cap in capabilities) {
+                foreach (var token in Tokenize(cap))
+                    yield return token;
+            }
+        }
+
+        internal static (IEnumerable<EnC.EditAndContinueCapabilities> capabilities, IEnumerable<string> unknowns) Parse (IEnumerable<Token> tokens)
+        {
+            List<string> unknowns = new();
+            List<EnC.EditAndContinueCapabilities> capabilities = new();
+            foreach (var tok in tokens)
+            {
+                if (ParseToken (tok, out var cap)) {
+                    capabilities.Add (cap);
+                } else {
+                    unknowns.Add (tok.Value);
+                }
+            }
+            return (capabilities, unknowns);
+        }
+
+        internal static (IEnumerable<EnC.EditAndContinueCapabilities> capabilities, IEnumerable<string> unknowns) Parse (string capabilities)
+        {
+            return Parse(Tokenize(capabilities));
+        }
+
+        internal static (IEnumerable<EnC.EditAndContinueCapabilities> capabilities, IEnumerable<string> unknowns) Parse (IEnumerable<string> capabilities)
+        {
+            return Parse(Tokenize(capabilities));
+        }
+
+        internal static bool ParseToken (Token token, out EnC.EditAndContinueCapabilities res) {
+            res = EnC.EditAndContinueCapabilities.None;
+            return Enum.TryParse<EnC.EditAndContinueCapabilities>(token.Value, ignoreCase: true, out res);
+        }
+
+    }
+}
+

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMaker.cs
@@ -89,14 +89,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
             return theirCaps;
         }
 
-        private object DefaultEditAndContinueCapabilities()
-        {
-            var myCaps = EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.AddMethodToExistingType
-                | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType
-                | EditAndContinueCapabilities.NewTypeDefinition;
-            return ConvertCapabilities(myCaps);
-        }
-        public Task<(DocumentAnalysisResultsWrapper, ImmutableArray<RudeEditDiagnosticWrapper>)> GetChanges(Project oldProject, Document newDocument, CancellationToken cancellationToken = default)
+                public Task<(DocumentAnalysisResultsWrapper, ImmutableArray<RudeEditDiagnosticWrapper>)> GetChanges(EditAndContinueCapabilities capabilities, Project oldProject, Document newDocument, CancellationToken cancellationToken = default)
         {
             // Effectively
             //
@@ -119,7 +112,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.EnC
 
             var textSpans = ImmutableArray.Create<TextSpan>();
 
-            var capabilities = DefaultEditAndContinueCapabilities();
+            var roslynCapabilities = ConvertCapabilities (capabilities);
 
             var taskResult = mi.Invoke (analyzer, new object[] {oldProject, activeStatements, newDocument, textSpans, capabilities, cancellationToken});
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
@@ -68,6 +68,11 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
             caps |= runnerCaps;
             if (caps == EnC.EditAndContinueCapabilities.None)
                 caps = DefaultCapabilities ();
+            if (!config.NoWarnUnknownCapabilities) {
+                foreach (var unk in unknowns) {
+                    Console.WriteLine ("Warning: Unknown EnC capability '{0}', ignored.", unk);
+                }
+            }
             return caps;
         }
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Runner.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.HotReload.Utils.Generator {
     public abstract class Runner {
+
         public static Runner Make (Config config)
         {
             if (config.Live)
@@ -19,7 +20,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
         public async Task Run (CancellationToken ct = default) {
             var baselineArtifacts = await SetupBaseline (ct);
 
-            var deltaProject = new DeltaProject (baselineArtifacts);
+            var deltaProject = new DeltaProject (baselineArtifacts, PrepareCapabilities());
             var derivedInputs = SetupDeltas (baselineArtifacts, ct);
 
             await GenerateDeltas (deltaProject, derivedInputs, makeOutputs: MakeOutputs, outputsReady: OutputsReady, ct: ct);
@@ -55,7 +56,28 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator {
             return baselineArtifacts;
         }
 
+        protected abstract EnC.EditAndContinueCapabilities PrepareCapabilitiesCore ();
 
+        protected EnC.EditAndContinueCapabilities PrepareCapabilities() {
+            EnC.EditAndContinueCapabilities caps = EnC.EditAndContinueCapabilities.None;
+            (var configuredCaps, var unknowns) = EditAndContinueCapabilitiesParser.Parse (config.EditAndContinueCapabilities);
+            foreach (var c in configuredCaps) {
+                caps |= c;
+            }
+            var runnerCaps = PrepareCapabilitiesCore ();
+            caps |= runnerCaps;
+            if (caps == EnC.EditAndContinueCapabilities.None)
+                caps = DefaultCapabilities ();
+            return caps;
+        }
+
+        protected EnC.EditAndContinueCapabilities DefaultCapabilities ()
+        {
+            var allCaps = EnC.EditAndContinueCapabilities.Baseline | EnC.EditAndContinueCapabilities.AddMethodToExistingType
+                | EnC.EditAndContinueCapabilities.AddStaticFieldToExistingType | EnC.EditAndContinueCapabilities.AddInstanceFieldToExistingType
+                | EnC.EditAndContinueCapabilities.NewTypeDefinition;
+            return allCaps;
+        }
         public abstract IAsyncEnumerable<Delta> SetupDeltas (BaselineArtifacts baselineArtifacts, CancellationToken ct = default);
 
         public async Task GenerateDeltas (DeltaProject deltaProject, IAsyncEnumerable<Delta> deltas,

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Runners/LiveRunner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Runners/LiveRunner.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Runners
             return Livecoding (baselineArtifacts, config.LiveCodingWatchDir, config.LiveCodingWatchPattern, ct);
         }
 
+        protected override EnC.EditAndContinueCapabilities PrepareCapabilitiesCore () => EnC.EditAndContinueCapabilities.None;
 
         private static async IAsyncEnumerable<Delta> Livecoding (BaselineArtifacts baselineArtifacts, string watchDir, string pattern, [EnumeratorCancellation] CancellationToken cancellationToken= default) {
             var last = DateTime.UtcNow;

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Runners/ScriptRunner.cs
@@ -44,6 +44,9 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator.Runners
 
         }
 
+        // TODO: read capabilities from JSON
+        protected override EnC.EditAndContinueCapabilities PrepareCapabilitiesCore () => EnC.EditAndContinueCapabilities.None;
+
         public override IAsyncEnumerable<Delta> SetupDeltas (BaselineArtifacts baselineArtifacts, CancellationToken ct = default)
         {
             return ScriptedPlanInputs (config, baselineArtifacts, ct);


### PR DESCRIPTION
Add a `-capabilities:Cap1,Cap2,...` option.

Partially addresses #21 - still need to add a way to pass them via .json delta files