### PR TITLE
Additional CI fixes

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/BaselineProject.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/BaselineProject.cs
@@ -51,7 +51,13 @@ namespace Microsoft.DotNet.HotReload.Utils.Generator
                         if (!warning)
                             throw new DiffyException ("failed workspace", 1);
                     };
-                    var project = await msw.OpenProjectAsync (config.ProjectPath, null, ct);
+                    Microsoft.Build.Framework.ILogger? logger = null;
+#if false
+                    logger = new Microsoft.Build.Logging.BinaryLogger () {
+                        Parameters = "/tmp/enc.binlog"
+                    };
+#endif
+                    var project = await msw.OpenProjectAsync (config.ProjectPath, logger, null, ct);
 
                     return (new EnC.ChangeMakerService(msw.Services, capabilities), msw.CurrentSolution, project.Id);
         }

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
     <!-- to support MSBuildWorkspace -->
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(RefOnlyMicrosoftBuildFrameworkVersion)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisVersion)" />
     <!-- added to fix error when opening an MSBuildWorkspace project:
         "ProcessFrameworkReferences" task failed unexpectedly.

--- a/tests/BuildTool/ImportExplcitly.Tests/Directory.Build.props
+++ b/tests/BuildTool/ImportExplcitly.Tests/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <!-- For some reason if we build this test assembly with ContinuousIntegrationBuild=true, the WatchHotReloadService refuses to generate deltas for it - and doesn't return and diagnostics. -->
-  <PropertyGroup>
-    <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  <Import Project="..\..\..\Directory.Build.props" />
-</Project>

--- a/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
@@ -6,6 +6,8 @@
     <Optimize>false</Optimize>
     <EmitDebugInformation>true</EmitDebugInformation>
     <DeltaScript>delta.json</DeltaScript>
+    <!-- CI sets this to true, but it breaks the EnC service's ability to understand the debug info.  Must be false for editable assemblies. -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Turns out it's the `DeterministicSourcePaths` property (which is set for CI builds) that broke the EnC service's ability to generate deltas in #65 