### PR TITLE
Allow Generator.BuildTool to run on newer SDK

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
@@ -4,6 +4,8 @@
     <Nullable>enable</Nullable>
     <TargetFramework>net6.0</TargetFramework>
     <PackageType>MSBuildSdk</PackageType>
+    <!-- Allow to run on later tooling (i.e. net7.0) if exact match isn't present -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Without the rollforward switch, dotnet/runtime fails to build on a .NET 7.0 SDK:

```
It was not possible to find any compatible framework version
  The framework 'Microsoft.NETCore.App', version '6.0.0' (x64) was not found.
    - The following frameworks were found:
        7.0.0-alpha.1.22065.6 at [C:\git\runtime3\.dotnet\shared\Microsoft.NETCore.App]

  You can resolve the problem by installing the specified framework and/or SDK.

  The specified framework can be found at:
    - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=win10-x64
C:\Users\vihofer\.nuget\packages\microsoft.dotnet.hotreload.utils.generator.buildtool\1.0.2-alpha.0.22060.2\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets(56,5): error MSB3073: The command ""C:\git\runtime3\.dotnet\dotnet.exe" C:\Users\vihofer\.nuget\packages\microsoft.dotnet.hotreload.utils.generator.buildtool\1.0.2-alpha.0.22060.2\build\..\tools\net6.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll -msbuild:C:\git\runtime3\src\libraries\System.Runtime.Loader\tests\ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate.csproj -script:C:\git\runtime3\src\libraries\System.Runtime.Loader\tests\ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate\deltascript.json -p:Configuration=Debug" exited with code -2147450730. [C:\git\runtime3\src\libraries\System.Runtime.Loader\tests\ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate.csproj]
```