### PR TITLE
Generate .handler.json output files

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/UpdateHandlerInfo.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/UpdateHandlerInfo.cs
@@ -1,0 +1,15 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+
+namespace Microsoft.DotNet.HotReload.Utils.Generator;
+
+public class UpdateHandlerInfo {
+
+    [JsonPropertyName("updatedTypes")]
+    public ImmutableArray<int> UpdatedTypes {get; init;}
+
+    public UpdateHandlerInfo(ImmutableArray<int> updatedTypes) {
+        UpdatedTypes = updatedTypes;
+    }
+}

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/UpdateHandlerInfo.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/UpdateHandlerInfo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaNaming.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaNaming.cs
@@ -16,6 +16,8 @@ public class DeltaNaming {
     public string Dmeta => _baseAssemblyPath + "." + Rev + ".dmeta";
     public string Dil => _baseAssemblyPath + "." + Rev + ".dil";
     public string Dpdb => _baseAssemblyPath + "." + Rev + ".dpdb";
+
+    public string UpdateHandlerInfo => _baseAssemblyPath + "." + Rev + ".handler.json";
     public int Rev => _rev;
 
     public DeltaNaming Next()

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaOutputStreams.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaOutputStreams.cs
@@ -11,22 +11,27 @@ public sealed class DeltaOutputStreams : IAsyncDisposable {
     public Stream  IlStream {get; private set;}
     public Stream PdbStream {get; private set;}
 
-    public DeltaOutputStreams(Stream dmeta, Stream dil, Stream dpdb) {
+    public Stream UpdateHandlerInfoStream {get; private set;}
+
+    public DeltaOutputStreams(Stream dmeta, Stream dil, Stream dpdb, Stream updateHandlerInfo) {
         MetaStream = dmeta;
         IlStream = dil;
         PdbStream = dpdb;
+        UpdateHandlerInfoStream = updateHandlerInfo;
     }
 
     public void Dispose () {
         MetaStream?.Dispose();
         IlStream?.Dispose();
         PdbStream?.Dispose();
+        UpdateHandlerInfoStream?.Dispose();
     }
 
     public async ValueTask DisposeAsync () {
         if  (MetaStream != null) await MetaStream.DisposeAsync();
         if  (IlStream != null) await IlStream.DisposeAsync();
         if  (PdbStream != null) await PdbStream.DisposeAsync();
+        if  (UpdateHandlerInfoStream != null) await UpdateHandlerInfoStream.DisposeAsync();
     }
 
 }

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
@@ -48,7 +48,8 @@ public class DeltaProject
         var metaStream = File.Create(dinfo.Dmeta);
         var ilStream = File.Create(dinfo.Dil);
         var pdbStream = File.Create(dinfo.Dpdb);
-        return new DeltaOutputStreams(metaStream, ilStream, pdbStream);
+        var updateHandlerInfoStream = File.Create(dinfo.UpdateHandlerInfo);
+        return new DeltaOutputStreams(metaStream, ilStream, pdbStream, updateHandlerInfoStream);
     }
 
     /// Builds a delta for the specified document given a path to its updated contents and a revision count
@@ -113,6 +114,7 @@ public class DeltaProject
             output.MetaStream.Write(update.MetadataDelta.AsSpan());
             output.IlStream.Write(update.ILDelta.AsSpan());
             output.PdbStream.Write(update.PdbDelta.AsSpan());
+            System.Text.Json.JsonSerializer.Serialize(output.UpdateHandlerInfoStream, new UpdateHandlerInfo (update.UpdatedTypes));
             outputsReady?.Invoke(dinfo, output);
         }
         Console.WriteLine($"wrote {dinfo.Dmeta}");


### PR DESCRIPTION
Generate an output file that contains the metadata update handler information:
- the list of type tokens of the updated types.

Fixes #152