### PR TITLE
"Clean-up hotreloads repo and define TFM centrally" & "Fix wrong TFM in shipping targets file"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
@@ -9,6 +9,12 @@
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
+
+    <!-- TODO: Remove when https://github.com/dotnet/arcade/pull/12161 is merged and consumed. -->
+    <NetCurrent Condition="'$(NetCurrent)' == ''">net8.0</NetCurrent>
+
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <Nullable Condition="'$(IsTestProject)' != 'true'">enable</Nullable>
 
     <!--
       Tools and packages produced by this repository support infrastructure and are not shipping on NuGet or via any other official channel.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
 </Project>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
+
   <ItemGroup>
-    <ProjectToBuild Include="$(MSBuildThisFileDirectory)..\hotreload-utils.proj" />
+    <ProjectToBuild Include="$(RepoRoot)hotreload-utils.proj" />
   </ItemGroup>
+
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
-   <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
-   </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
+
   <PropertyGroup>
     <!-- This repo version -->
     <!-- Base three-part version used for all outputs of the repo (assemblies, packages, vsixes) -->
@@ -31,4 +31,5 @@
     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>
     <RefOnlyNugetProjectModelVersion>6.2.2</RefOnlyNugetProjectModelVersion>
   </PropertyGroup>
+
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,6 +3,7 @@
     "dotnet": "8.0.100-alpha.1.23055.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23058.1"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23058.1",
+    "Microsoft.Build.Traversal": "3.2.0"
   }
 }

--- a/hotreload-utils.proj
+++ b/hotreload-utils.proj
@@ -1,4 +1,5 @@
-<Project Sdk="Microsoft.Build.Traversal/3.0.3">
+<Project Sdk="Microsoft.Build.Traversal">
+
   <ItemGroup>
     <ProjectReference Include="src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj" />
     <ProjectReference Include="src/Microsoft.DotNet.HotReload.Utils.Generator.Data/Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
@@ -9,4 +10,5 @@
 
     <ProjectReference Include="tests\**\*.*proj" />
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
     <PackageType>MSBuildSdk</PackageType>
-    <!-- Allow to run on later tooling (i.e. net7.0) if exact match isn't present -->
-    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageType>MSBuildSdk</PackageType>
+    <!-- Allow to run on later tooling if exact match isn't present -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
@@ -5,11 +5,11 @@
     <!-- If DotNetTool is undefined, we default to assuming 'dotnet' is on the path -->
     <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
 
-    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 
     <_HotReloadDeltaGeneratorCommand>"$(DotNetTool)" $(_HotReloadDeltaGeneratorPath)</_HotReloadDeltaGeneratorCommand>
 
-    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net7.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,7 +17,6 @@
     <_HotReloadDeltaGeneratorShouldRun Condition="'$(_HotReloadDeltaGeneratorShouldRun)' == '' and Exists('$(_HotReloadDeltaGeneratorDeltaScript)')">true</_HotReloadDeltaGeneratorShouldRun>
     <_HotReloadDeltaGeneratorShouldRun Condition="'$(_HotReloadDeltaGeneratorShouldRun)' == ''">false</_HotReloadDeltaGeneratorShouldRun>
   </PropertyGroup>
-
 
   <UsingTask TaskName="HotReloadDeltaGeneratorComputeScriptOutputs" AssemblyFile="$(_HotReloadDeltaGeneratorTasksPath)" />
 
@@ -66,6 +65,5 @@
       </Content>
     </ItemGroup>
   </Target>
-
 
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Data/Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj
@@ -1,7 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Frontend/Microsoft.DotNet.HotReload.Utils.Generator.Frontend.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Frontend/Microsoft.DotNet.HotReload.Utils.Generator.Frontend.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator\Microsoft.DotNet.HotReload.Utils.Generator.csproj" />

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
@@ -1,9 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(RefOnlyMicrosoftBuildVersion)" />
@@ -15,4 +10,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator.Data\Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -36,4 +31,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator.Data\Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/hotreload-delta-gen/README.md
+++ b/src/hotreload-delta-gen/README.md
@@ -9,12 +9,12 @@ For integration into MS Build projects, see [../Microsoft.DotNet.HotReload.Utils
 
 The standalone `hotreload-delta-gen` tool is more useful for one-off experiments in which case it is best to install it as a global dotnet tool.
 
-## How to install from the dotnet7-transport NuGet feed
+## How to install from the dotnet8-transport NuGet feed
 
-Preview versions are published to the `dotnet7-transport` feed.
+Preview versions are published to the `dotnet8-transport` feed.
 
 ```console
-dotnet tool install --global --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json hotreload-delta-gen --version [LATEST_VER]
+dotnet tool install --global --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json hotreload-delta-gen --version [LATEST_VER]
 ```
 
 Where `[LATEST_VER]` is the latest published version (`dotnet tool install` will tell you the latest available if you omit the `--version` argument)
@@ -27,7 +27,7 @@ Install .NET 7
 
 Run `build.sh -restore -build -publish -pack -c Release` from the repo root.
 
-That will create the executable `artifacts/bin/hotreload-delta-gen/Release/net7.0/publish/hotreload-delta-gen`.
+That will create the executable `artifacts/bin/hotreload-delta-gen/Release/net8.0/publish/hotreload-delta-gen`.
 
 
 ## How to use it

--- a/src/hotreload-delta-gen/example/TestClass.csproj
+++ b/src/hotreload-delta-gen/example/TestClass.csproj
@@ -1,35 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <OutputType>library</OutputType>
-        <EnableDefaultItems>false</EnableDefaultItems>
-        <DeltaScript>diffscript.json</DeltaScript>
-    </PropertyGroup>
-    <ItemGroup>
-      <Compile Include="TestClass.cs"/>
-      <ProjectReference Include="..\src\hotreload-delta-gen.csproj" ReferenceOutputAssembly="false" />
-    </ItemGroup>
 
-    <!-- find the built hotreload-delta-gen.dll from this repo -->
-    <PropertyGroup>
-      <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
-      <ToolConfiguration Condition="'$(ToolConfiguration)'==''">$(Configuration)</ToolConfiguration>
-      <ToolTargetFramework Condition="'$(ToolTargetFramework)'==''">$(TargetFramework)</ToolTargetFramework>
-      <HotReloadToolPath>$(OutputPath)\..\..\hotreload-delta-gen\$(ToolConfiguration)\$(ToolTargetFramework)\hotreload-delta-gen.dll</HotReloadToolPath>
-      <HotReloadToolCommand>$(DotNetTool) $(HotReloadToolPath)</HotReloadToolCommand>
-    </PropertyGroup>
+  <PropertyGroup>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <DeltaScript>diffscript.json</DeltaScript>
+  </PropertyGroup>
 
-    <!-- run the tool after this assembly is built -->
-    <Target Name="RunDiff" AfterTargets="Build">
-      <PropertyGroup>
-        <HotReloadGeneratorArgs>-msbuild:$(MSBuildProjectFullPath)</HotReloadGeneratorArgs>
-        <HotReloadGeneratorArgs>$(HotReloadGeneratorArgs) -script:$(DeltaScript)</HotReloadGeneratorArgs>
-        <HotReloadGeneratorArgs Condition="'$(Configuration)' != ''">$(HotReloadGeneratorArgs) -p:Configuration=$(Configuration)</HotReloadGeneratorArgs>
-        <HotReloadGeneratorArgs Condition="'$(RuntimeIdentifier)' != ''">$(HotReloadGeneratorArgs) -p:RuntimeIdentifier=$(RuntimeIdentifier)</HotReloadGeneratorArgs>
-        <HotReloadGeneratorArgs Condition="'$(BuiltRuntimeConfiguration)' != ''">$(HotReloadGeneratorArgs) -p:BuiltRuntimeConfiguration=$(BuiltRuntimeConfiguration)</HotReloadGeneratorArgs>
-        <HotReloadGeneratorArgs>$(HotReloadGeneratorArgs) -outputSummary:$(OutputPath)\hotreload-delta-gen-summary.json</HotReloadGeneratorArgs>
-      </PropertyGroup>
-      <Exec Command="$(HotReloadToolCommand) $(HotReloadGeneratorArgs)" />
-    </Target>
+  <ItemGroup>
+    <Compile Include="TestClass.cs"/>
+    <ProjectReference Include="..\src\hotreload-delta-gen.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- find the built hotreload-delta-gen.dll from this repo -->
+  <PropertyGroup>
+    <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
+    <ToolConfiguration Condition="'$(ToolConfiguration)'==''">$(Configuration)</ToolConfiguration>
+    <ToolTargetFramework Condition="'$(ToolTargetFramework)'==''">$(TargetFramework)</ToolTargetFramework>
+    <HotReloadToolPath>$(OutputPath)\..\..\hotreload-delta-gen\$(ToolConfiguration)\$(ToolTargetFramework)\hotreload-delta-gen.dll</HotReloadToolPath>
+    <HotReloadToolCommand>$(DotNetTool) $(HotReloadToolPath)</HotReloadToolCommand>
+  </PropertyGroup>
+
+  <!-- run the tool after this assembly is built -->
+  <Target Name="RunDiff" AfterTargets="Build">
+    <PropertyGroup>
+      <HotReloadGeneratorArgs>-msbuild:$(MSBuildProjectFullPath)</HotReloadGeneratorArgs>
+      <HotReloadGeneratorArgs>$(HotReloadGeneratorArgs) -script:$(DeltaScript)</HotReloadGeneratorArgs>
+      <HotReloadGeneratorArgs Condition="'$(Configuration)' != ''">$(HotReloadGeneratorArgs) -p:Configuration=$(Configuration)</HotReloadGeneratorArgs>
+      <HotReloadGeneratorArgs Condition="'$(RuntimeIdentifier)' != ''">$(HotReloadGeneratorArgs) -p:RuntimeIdentifier=$(RuntimeIdentifier)</HotReloadGeneratorArgs>
+      <HotReloadGeneratorArgs Condition="'$(BuiltRuntimeConfiguration)' != ''">$(HotReloadGeneratorArgs) -p:BuiltRuntimeConfiguration=$(BuiltRuntimeConfiguration)</HotReloadGeneratorArgs>
+      <HotReloadGeneratorArgs>$(HotReloadGeneratorArgs) -outputSummary:$(OutputPath)\hotreload-delta-gen-summary.json</HotReloadGeneratorArgs>
+    </PropertyGroup>
+    <Exec Command="$(HotReloadToolCommand) $(HotReloadGeneratorArgs)" />
+  </Target>
 
 </Project>

--- a/src/hotreload-delta-gen/src/hotreload-delta-gen.csproj
+++ b/src/hotreload-delta-gen/src/hotreload-delta-gen.csproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.DotNet.HotReload.Utils.Generator.Frontend\Microsoft.DotNet.HotReload.Utils.Generator.Frontend.csproj" />
-  </ItemGroup>
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <PackageId>hotreload-delta-gen</PackageId>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.DotNet.HotReload.Utils.Generator.Frontend\Microsoft.DotNet.HotReload.Utils.Generator.Frontend.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.DotNet.HotReload.Utils.Generator\Microsoft.DotNet.HotReload.Utils.Generator.csproj" />

--- a/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <!-- NOTE: no DeltaScript property - importing the BuildTool.targets should have no effect -->
   </PropertyGroup>
 
   <Import Project="..\ImportExplicitly.props" />
-
   <Import Project="$(InTreeGeneratorBuildToolTargetsPath)" />
+
 </Project>

--- a/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
+++ b/tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="ContinuousIntegrationBuild;Optimize;EmitDebugInformation">
+
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
     <Optimize>false</Optimize>
     <EmitDebugInformation>true</EmitDebugInformation>
@@ -16,6 +15,6 @@
   </ItemGroup>
 
   <Import Project="..\ImportExplicitly.props" />
-
   <Import Project="$(InTreeGeneratorBuildToolTargetsPath)" />
+
 </Project>

--- a/tests/BuildTool/ImportExplicitly.props
+++ b/tests/BuildTool/ImportExplicitly.props
@@ -1,20 +1,15 @@
 <Project>
 
   <!-- Set the paths for the generator buildtool and tasks assemblies explicitly so that we can Import the in-tree BuildTool.targets file -->
-
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
-  </ItemGroup>
-
-  <!-- explicitly set tool path -->
   <PropertyGroup>
+    <InTreeGeneratorBuildToolTargetsPath>$(RepoRoot)src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</InTreeGeneratorBuildToolTargetsPath>
     <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
     <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <InTreeGeneratorBuildToolTargetsPath>$(MSBuildThisFileDirectory)..\..\src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</InTreeGeneratorBuildToolTargetsPath>
-  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(RepoRoot)src\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Commit 1: **Clean-up hotreloads repo and define TFM centrally**
- Define TFM centrally for all projects and update docs
- Remove IsPackable=false which is the default Arcade setting
- Define Nullable=enable centrally for non test projects
- Remove not needed msbuild xml syntax and clean-up project files
- Style nits

Commit 2: **Fix wrong TFM in shipping targets file**
- Regressed with https://github.com/dotnet/hotreload-utils/pull/229

cc @lambdageek 