### PR TITLE
Fix release/6.0 build

### DIFF
--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -92,18 +92,18 @@ public class TempMSBuildWorkspaceTest : IClassFixture<MSBuildLocatorFixture>, IC
 
     protected async Task<Project> PrepareProject(CancellationToken cancellationToken = default)
     {
-        (var solution, var projectId) = await CreateProject("""
-            <Project Sdk="Microsoft.NET.Sdk">
+        (var solution, var projectId) = await CreateProject(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
                 <PropertyGroup>
                     <OutputType>Library</OutputType>
                     <TargetFramework>net8.0</TargetFramework>
                     <EnableDefaultItems>false</EnableDefaultItems>
                 </PropertyGroup>
                 <ItemGroup>
-                    <!-- Compile Include="Program.cs" -->
+                    <!-- Compile Include=""Program.cs"" -->
                 </ItemGroup>
             </Project>
-            """, cancellationToken);
+            ", cancellationToken);
         Assert.NotNull(solution);
         var project = solution.GetProject(projectId);
         Assert.NotNull(project);

--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -96,7 +96,7 @@ public class TempMSBuildWorkspaceTest : IClassFixture<MSBuildLocatorFixture>, IC
             <Project Sdk=""Microsoft.NET.Sdk"">
                 <PropertyGroup>
                     <OutputType>Library</OutputType>
-                    <TargetFramework>net8.0</TargetFramework>
+                    <TargetFramework>net6.0</TargetFramework>
                     <EnableDefaultItems>false</EnableDefaultItems>
                 </PropertyGroup>
                 <ItemGroup>

--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -121,11 +121,12 @@ public class TempMSBuildWorkspaceTest : IClassFixture<MSBuildLocatorFixture>, IC
     {
         if (!emitResult.Success)
         {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
             foreach (var diag in emitResult.Diagnostics)
             {
-                Console.WriteLine(diag);
+                sb.AppendLine(diag.ToString());
             }
-            Assert.True(false, $"{file}:{line} EmitResult failed in {caller}");
+            Assert.True(false, $"{file}:{line} EmitResult failed in {caller} due to {sb}");
         }
     }
 

--- a/tests/HotReload.Generator/EnC.Tests/WatchHotReloadServiceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/WatchHotReloadServiceTest.cs
@@ -26,14 +26,14 @@ public class WatchHotReloadServiceTest : TempMSBuildWorkspaceTest
     {
         var cancellationToken = CancellationToken.None;
         var project = await PrepareProject(cancellationToken);
-        var src = MakeText("""
+        var src = MakeText(@"
             using System;
             public class C1 {
                 public static void M1() {
-                    Console.WriteLine("Hello");
+                    Console.WriteLine(""Hello"");
                 }
             }
-            """);
+            ");
         WithBaselineSource(ref project, "Class1.cs", src, out var d);
         var comp = await project.GetCompilationAsync(cancellationToken);
         Assert.NotNull(comp);


### PR DESCRIPTION
1. Use net6.0 SDK not net8.0 SDK in smoketest project
2. Don't use too-new C# features
3. improve failure diagnostics by capturing roslyn diagnostics into the xUnit assertion failure message