### PR TITLE
change SDK version for TempMSBuildWorkspaceTest to net7.0

### DIFF
--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -96,7 +96,7 @@ public class TempMSBuildWorkspaceTest : IClassFixture<MSBuildLocatorFixture>, IC
             <Project Sdk="Microsoft.NET.Sdk">
                 <PropertyGroup>
                     <OutputType>Library</OutputType>
-                    <TargetFramework>net8.0</TargetFramework>
+                    <TargetFramework>net7.0</TargetFramework>
                     <EnableDefaultItems>false</EnableDefaultItems>
                 </PropertyGroup>
                 <ItemGroup>


### PR DESCRIPTION
since that's the SDK that MSBuildLocator will find in memory