### PR TITLE
Permit path spaces in HotReload generator path in the build tool.

### DIFF
--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets
@@ -7,7 +7,7 @@
 
     <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 
-    <_HotReloadDeltaGeneratorCommand>"$(DotNetTool)" $(_HotReloadDeltaGeneratorPath)</_HotReloadDeltaGeneratorCommand>
+    <_HotReloadDeltaGeneratorCommand>"$(DotNetTool)" "$(_HotReloadDeltaGeneratorPath)"</_HotReloadDeltaGeneratorCommand>
 
     <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net8.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
@@ -41,8 +41,8 @@
       Outputs="@(_HotReloadDeltaGeneratorOutputs)"
       >
     <PropertyGroup>
-      <_HotReloadDeltaGeneratorArgs>-msbuild:$(MSBuildProjectFullPath)</_HotReloadDeltaGeneratorArgs>
-      <_HotReloadDeltaGeneratorArgs>$(_HotReloadDeltaGeneratorArgs) -script:$(_HotReloadDeltaGeneratorDeltaScript)</_HotReloadDeltaGeneratorArgs>
+      <_HotReloadDeltaGeneratorArgs>"-msbuild:$(MSBuildProjectFullPath)"</_HotReloadDeltaGeneratorArgs>
+      <_HotReloadDeltaGeneratorArgs>$(_HotReloadDeltaGeneratorArgs) "-script:$(_HotReloadDeltaGeneratorDeltaScript)"</_HotReloadDeltaGeneratorArgs>
 
       <!-- This is a little bit delicate: we're invoking a design-time msbuild here, and we need it to come back with the same OutputPath as the current
           run of msbuild.  If there are other properties that affect where the baseline assembly ends up, we need to pass those here too.


### PR DESCRIPTION
Currently, `Microsoft.DotNet.HotReload.Utils.Generator.BuildTool` does not expect the path to the HotReload delta generator to contain any spaces, which may not always be guaranteed, particularly on Windows installations where the running user's name contains a space, as the default Nuget cache path is placed under the user directory.

This issue appeared when attempting to build the runtime (`coreclr+libs`) using Ninja natively on Windows on Arm.

This patch simply appends quotes around relevant arguments so that paths containing spaces are correctly contained within their appropriate argument.