### PR TITLE
Replace hardcoded net9.0 TFM in build .targets

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -20,6 +20,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2f7acdc5f9b87f260119bb32d01c24d2773773eb</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="9.0.0-beta.23615.2">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2f7acdc5f9b87f260119bb32d01c24d2773773eb</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="9.0.0-beta.23615.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2f7acdc5f9b87f260119bb32d01c24d2773773eb</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,8 @@
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetBuildTasksPackageVersion>6.9.0-preview.1.64</NuGetBuildTasksPackageVersion>
     <NuGetFrameworksPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetFrameworksPackageVersion>
-    <!-- Testing -->
+    <!-- arcade -->
+    <MicrosoftDotNetBuildTasksTemplatingVersion>9.0.0-beta.23615.2</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>9.0.0-beta.23615.2</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>9.0.0-beta.23615.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.6.1-beta.23615.2</MicrosoftDotNetXUnitConsoleRunnerVersion>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
@@ -29,7 +29,7 @@
 
     <GenerateFileFromTemplate TemplateFile="$(HotReloadTargetsTemplateFile)"
                               OutputPath="$(HotReloadTargetsOutputFile)"
-                              Properties="NetCurrent=$(NetCurrent)">
+                              Properties="NetToolCurrent=$(NetToolCurrent)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj
@@ -13,6 +13,33 @@
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" ExcludeAssets="runtime"  />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <HotReloadTargetsTemplateFile>Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in</HotReloadTargetsTemplateFile>
+    <HotReloadTargetsOutputFile>$(IntermediateOutputPath)Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</HotReloadTargetsOutputFile>
+  </PropertyGroup>
+
+  <Target Name="ReplaceTemplateParametersInHotReloadTargetsTemplate"
+          Inputs="$(HotReloadTargetsTemplateFile)"
+          Outputs="$(HotReloadTargetsOutputFile)"
+          BeforeTargets="Build">
+
+    <GenerateFileFromTemplate TemplateFile="$(HotReloadTargetsTemplateFile)"
+                              OutputPath="$(HotReloadTargetsOutputFile)"
+                              Properties="NetCurrent=$(NetCurrent)">
+      <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
+    </GenerateFileFromTemplate>
+
+    <ItemGroup>
+      <None Include="$(HotReloadTargetsOutputFile)" Pack="true">
+        <PackagePath>build/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</PackagePath>
+      </None>
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 
 </Project>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in
@@ -5,11 +5,13 @@
     <!-- If DotNetTool is undefined, we default to assuming 'dotnet' is on the path -->
     <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
 
-    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
+    <_HotReloadDeltaGeneratorTFM Condition="'$(_HotReloadDeltaGeneratorTFM)' == ''">${NetCurrent}</_HotReloadDeltaGeneratorTFM>
+
+    <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\$(_HotReloadDeltaGeneratorTFM)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 
     <_HotReloadDeltaGeneratorCommand>"$(DotNetTool)" "$(_HotReloadDeltaGeneratorPath)"</_HotReloadDeltaGeneratorCommand>
 
-    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net9.0\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
+    <_HotReloadDeltaGeneratorTasksPath Condition="'$(_HotReloadDeltaGeneratorTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\$(_HotReloadDeltaGeneratorTFM)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in
@@ -5,7 +5,7 @@
     <!-- If DotNetTool is undefined, we default to assuming 'dotnet' is on the path -->
     <DotNetTool Condition="'$(DotNetTool)' == ''">dotnet</DotNetTool>
 
-    <_HotReloadDeltaGeneratorTFM Condition="'$(_HotReloadDeltaGeneratorTFM)' == ''">${NetCurrent}</_HotReloadDeltaGeneratorTFM>
+    <_HotReloadDeltaGeneratorTFM Condition="'$(_HotReloadDeltaGeneratorTFM)' == ''">${NetToolCurrent}</_HotReloadDeltaGeneratorTFM>
 
     <_HotReloadDeltaGeneratorPath Condition="'$(_HotReloadDeltaGeneratorPath)' == ''">$(MSBuildThisFileDirectory)..\tools\$(_HotReloadDeltaGeneratorTFM)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
 

--- a/src/hotreload-delta-gen/README.md
+++ b/src/hotreload-delta-gen/README.md
@@ -25,7 +25,7 @@ Then run the tool as `hotreload-delta-gen` assuming that `${HOME}/.dotnet/tools`
 
 Run `build.sh -restore -build -publish -pack -c Release` from the repo root.
 
-That will create the executable `artifacts/bin/hotreload-delta-gen/Release/net9.0/publish/hotreload-delta-gen`.
+That will create the executable `artifacts/bin/hotreload-delta-gen/Release/<dotnet version>/publish/hotreload-delta-gen`.
 
 
 ## How to use it

--- a/tests/BuildTool/ImportExplicitly.props
+++ b/tests/BuildTool/ImportExplicitly.props
@@ -2,7 +2,9 @@
 
   <!-- Set the paths for the generator buildtool and tasks assemblies explicitly so that we can Import the in-tree BuildTool.targets file -->
   <PropertyGroup>
-    <InTreeGeneratorBuildToolTargetsPath>$(RepoRoot)src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\build\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets</InTreeGeneratorBuildToolTargetsPath>
+    <!-- Override the TFM in the template file -->
+    <_HotReloadDeltaGeneratorTFM>$(NetCurrent)</_HotReloadDeltaGeneratorTFM>
+    <InTreeGeneratorBuildToolTargetsPath>$(RepoRoot)src\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.targets.in</InTreeGeneratorBuildToolTargetsPath>
     <_HotReloadDeltaGeneratorPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.dll</_HotReloadDeltaGeneratorPath>
     <_HotReloadDeltaGeneratorTasksPath>$(BaseOutputPath)..\Microsoft.DotNet.HotReload.Utils.Generator.Tasks\$(Configuration)\$(TargetFramework)\Microsoft.DotNet.HotReload.Utils.Generator.Tasks.dll</_HotReloadDeltaGeneratorTasksPath>
   </PropertyGroup>

--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -92,11 +92,12 @@ public class TempMSBuildWorkspaceTest : IClassFixture<MSBuildLocatorFixture>, IC
 
     protected async Task<Project> PrepareProject(CancellationToken cancellationToken = default)
     {
-        (var solution, var projectId) = await CreateProject("""
+        string targetFramework = $"net{Environment.Version.Major}.{Environment.Version.Minor}";
+        (var solution, var projectId) = await CreateProject($"""
             <Project Sdk="Microsoft.NET.Sdk">
                 <PropertyGroup>
                     <OutputType>Library</OutputType>
-                    <TargetFramework>net9.0</TargetFramework>
+                    <TargetFramework>{targetFramework}</TargetFramework>
                     <EnableDefaultItems>false</EnableDefaultItems>
                 </PropertyGroup>
                 <ItemGroup>


### PR DESCRIPTION
We can generate it dynamically instead. Eventually there should be an arcade feature for this: https://github.com/dotnet/arcade/issues/14138