### PR TITLE
Remove Microsoft.CodeAnalysis.Analyzers from Version.Details.xml

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,10 +5,6 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>1ce264cab372119376a734a247e9f60fe898877a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-      <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
-      <Sha>294f95cd91a33365aa80117421aed139d8fe5a75</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.24430.1">


### PR DESCRIPTION
This dependency is manually updated, we don't have a subscription for it.