### PR TITLE
Bump STJ and System.Formats.Asn1 versions 

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     <!-- Libs -->
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>4.12.0-3.24574.8</MicrosoftCodeAnalysisVersion>
-    <SystemFormatsAsn1Version>7.0.0</SystemFormatsAsn1Version>
-    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
+    <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.24578.2</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.24578.2</MicrosoftDotNetRemoteExecutorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,8 @@
     <!-- Libs -->
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>4.12.0-3.24558.5</MicrosoftCodeAnalysisVersion>
+    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
+    <SystemTextJsonToolsetVersion>8.0.5</SystemTextJsonToolsetVersion>
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.24564.1</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.24564.1</MicrosoftDotNetRemoteExecutorVersion>
@@ -21,7 +23,7 @@
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.
     -->
-    <RefOnlyMicrosoftBuildVersion>17.12.6</RefOnlyMicrosoftBuildVersion>
+    <RefOnlyMicrosoftBuildVersion>17.8.3</RefOnlyMicrosoftBuildVersion>
     <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     <!-- Libs -->
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>4.12.0-3.24574.8</MicrosoftCodeAnalysisVersion>
-    <SystemFormatsAsn1Version>8.0.1</SystemFormatsAsn1Version>
-    <SystemTextJsonToolsetVersion>8.0.5</SystemTextJsonToolsetVersion>
+    <SystemFormatsAsn1Version>7.0.0</SystemFormatsAsn1Version>
+    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
     <!-- arcade -->
     <MicrosoftDotNetBuildTasksTemplatingVersion>10.0.0-beta.24578.2</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>10.0.0-beta.24578.2</MicrosoftDotNetRemoteExecutorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.
     -->
-    <RefOnlyMicrosoftBuildVersion>17.8.3</RefOnlyMicrosoftBuildVersion>
+    <RefOnlyMicrosoftBuildVersion>17.12.6</RefOnlyMicrosoftBuildVersion>
     <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
-    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj
@@ -7,6 +7,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator.Data\Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -15,6 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+
+    <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.HotReload.Utils.Generator.Data\Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" />
     <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
     <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj
@@ -15,11 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
-
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
     <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
-    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -8,4 +8,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
   </ItemGroup>
 

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
   </ItemGroup>
 
 </Project>

--- a/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
+++ b/tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
+++ b/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" />
     <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
     <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>

--- a/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
+++ b/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
@@ -14,11 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
-
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" ExcludeAssets="All" PrivateAssets="all" NoWarn="NU1901;NU1902;NU1903;NU1904" />
     <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
-    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
+++ b/tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj
@@ -14,6 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The SDK distributes the live version of Json we can't reference that https://github.com/dotnet/runtime/issues/108262 -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+
+    <!-- Upgrade to a non-vulnerable version of Asn1 - which will be ignored in favor of the framework copy  -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" ExcludeAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="..\..\..\global.json" LogicalName="projectData/global.json" />
     <EmbeddedResource Include="..\..\..\NuGet.config" LogicalName="projectData/NuGet.config" />
   </ItemGroup>


### PR DESCRIPTION
Since we can't bump the MSBuild packages, we have to bump the components directly where they are used to satisfy CG