### PR TITLE
[release/10.0] Fix watch api usage (second try)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ publish/
 *.dil
 *.dmeta
 *.dpdb
+/.vs/
 /.vscode/
 /out/

--- a/HotReloadUtils.slnx
+++ b/HotReloadUtils.slnx
@@ -1,0 +1,14 @@
+<Solution>
+  <Folder Name="/tests/">
+    <Project Path="tests/Acceptance/EncCapabilitiesCompat.Tests/EncCapabilitiesCompat.Tests.csproj" />
+    <Project Path="tests/BuildTool/ImportExplcitly.ShouldNotRun.Tests/ImportExplicitly.ShouldNotRun.Tests.csproj" />
+    <Project Path="tests/BuildTool/ImportExplcitly.Tests/ImportExplicitly.Tests.csproj" />
+    <Project Path="tests/HotReload.Generator/EnC.Tests/EnC.Tests.csproj" />
+  </Folder>
+  <Project Path="src/hotreload-delta-gen/src/hotreload-delta-gen.csproj" />
+  <Project Path="src/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool/Microsoft.DotNet.HotReload.Utils.Generator.BuildTool.csproj" />
+  <Project Path="src/Microsoft.DotNet.HotReload.Utils.Generator.Data/Microsoft.DotNet.HotReload.Utils.Generator.Data.csproj" />
+  <Project Path="src/Microsoft.DotNet.HotReload.Utils.Generator.Frontend/Microsoft.DotNet.HotReload.Utils.Generator.Frontend.csproj" />
+  <Project Path="src/Microsoft.DotNet.HotReload.Utils.Generator.Tasks/Microsoft.DotNet.HotReload.Utils.Generator.Tasks.csproj" />
+  <Project Path="src/Microsoft.DotNet.HotReload.Utils.Generator/Microsoft.DotNet.HotReload.Utils.Generator.csproj" />
+</Solution>

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/DeltaProject.cs
@@ -94,17 +94,20 @@ public class DeltaProject
 
         var updates2 = await _changeMakerService.EmitSolutionUpdateAsync (updatedSolution, ct);
 
-        if (updates2.CompilationDiagnostics.Any()) {
+        if (updates2.CompilationDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error)) {
             var sb = new StringBuilder();
             foreach (var diag in updates2.CompilationDiagnostics) {
                 sb.AppendLine (diag.ToString ());
             }
             throw new DiffyException ($"Failed to emit delta for {oldDocument.Name}: {sb}", exitStatus: 8);
         }
+
         foreach (var fancyChange in updates2.ProjectUpdates)
         {
             Console.WriteLine("change service made {0}", fancyChange.ModuleId);
         }
+
+        _changeMakerService.CommitUpdate();
 
         await using (var output = makeOutputs != null ?  makeOutputs(dinfo) : DefaultMakeFileOutputs(dinfo)) {
             if (updates2.ProjectUpdates.Length != 1) {

--- a/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMakerService.cs
+++ b/src/Microsoft.DotNet.HotReload.Utils.Generator/EnC/ChangeMakerService.cs
@@ -169,6 +169,16 @@ public class ChangeMakerService
         mi.Invoke(_watchHotReloadService, Array.Empty<object>());
     }
 
+    public void CommitUpdate()
+    {
+        var mi = _watchServiceType.GetMethod("CommitUpdate");
+        if (mi == null)
+        {
+            throw new Exception($"could not find method {watchServiceName}.CommitUpdate");
+        }
+        mi.Invoke(_watchHotReloadService, Array.Empty<object>());
+    }
+
     public Task<Updates2> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
     {
         var runningProjectInfoType = _watchServiceType.GetNestedType("RunningProjectInfo", BindingFlags.Public)!;

--- a/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
+++ b/tests/HotReload.Generator/EnC.Tests/TempMSBuildWorkspaceTest.cs
@@ -113,7 +113,7 @@ public class TempMSBuildWorkspaceTest : IClassFixture<GlobalFilesFixture>, IDisp
 
     protected void WithBaselineSource(ref Project project, string csFileName, SourceText src, out DocumentId docId)
     {
-        var d = project.AddDocument(csFileName, src);
+        var d = project.AddDocument(csFileName, src, filePath: Path.Combine(project.FilePath!, csFileName));
         project = d.Project;
         docId = d.Id;
     }


### PR DESCRIPTION
Backport of #605 to release/10.0 (second try because I messed up the branch in https://github.com/dotnet/hotreload-utils/pull/608)

Necessary to fix the build breakages in https://github.com/dotnet/runtime/pull/118803